### PR TITLE
Potential issue in modules/imgproc/src/histogram.cpp: Unchecked return from initialization function

### DIFF
--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -2468,7 +2468,7 @@ cvThreshHist( CvHistogram* hist, double thresh )
 
     if( !CV_IS_SPARSE_MAT(hist->bins) )
     {
-        CvMat mat;
+        CvMat mat = {};
         cvGetMat( hist->bins, &mat, 0, 1 );
         cvThreshold( &mat, &mat, thresh, 0, CV_THRESH_TOZERO );
     }
@@ -2500,7 +2500,7 @@ cvNormalizeHist( CvHistogram* hist, double factor )
 
     if( !CV_IS_SPARSE_HIST(hist) )
     {
-        CvMat mat;
+        CvMat mat = {};
         cvGetMat( hist->bins, &mat, 0, 1 );
         sum = cvSum( &mat ).val[0];
         if( fabs(sum) < DBL_EPSILON )
@@ -2549,7 +2549,7 @@ cvGetMinMaxHistValue( const CvHistogram* hist,
 
     if( !CV_IS_SPARSE_HIST(hist) )
     {
-        CvMat mat;
+        CvMat mat = {};
         CvPoint minPt = {0, 0}, maxPt = {0, 0};
 
         cvGetMat( hist->bins, &mat, 0, 1 );


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

3 instances of this defect were found in the following locations:
---
**Instance 1**
File : `modules/imgproc/src/histogram.cpp` 
Function: `cvGetMat` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/imgproc/src/histogram.cpp#L2472
Code extract:

```cpp
    if( !CV_IS_SPARSE_MAT(hist->bins) )
    {
        CvMat mat;
        cvGetMat( hist->bins, &mat, 0, 1 ); <------ HERE
        cvThreshold( &mat, &mat, thresh, 0, CV_THRESH_TOZERO );
    }
```

---
**Instance 2**
File : `modules/imgproc/src/histogram.cpp` 
Function: `cvGetMat` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/imgproc/src/histogram.cpp#L2504
Code extract:

```cpp
    if( !CV_IS_SPARSE_HIST(hist) )
    {
        CvMat mat;
        cvGetMat( hist->bins, &mat, 0, 1 ); <------ HERE
        sum = cvSum( &mat ).val[0];
        if( fabs(sum) < DBL_EPSILON )
```

---
**Instance 3**
File : `modules/imgproc/src/histogram.cpp` 
Function: `cvGetMat` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/imgproc/src/histogram.cpp#L2555
Code extract:

```cpp
        CvMat mat;
        CvPoint minPt = {0, 0}, maxPt = {0, 0};

        cvGetMat( hist->bins, &mat, 0, 1 ); <------ HERE
        cvMinMaxLoc( &mat, &minVal, &maxVal, &minPt, &maxPt );

```

