### PR TITLE
Potential issue in 3rdparty/libwebp/src/enc/histogram_enc.c: Unchecked return from initialization function

### DIFF
--- a/3rdparty/libwebp/src/enc/histogram_enc.c
+++ b/3rdparty/libwebp/src/enc/histogram_enc.c
@@ -840,7 +840,7 @@ static int HistogramCombineGreedy(VP8LHistogramSet* const image_histo,
   int i, j;
   VP8LHistogram** const histograms = image_histo->histograms;
   // Priority queue of histogram pairs.
-  HistoQueue histo_queue;
+  HistoQueue histo_queue = {};
 
   // image_histo_size^2 for the queue size is safe. If you look at
   // HistogramCombineGreedy, and imagine that UpdateQueueFront always pushes


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `3rdparty/libwebp/src/enc/histogram_enc.c` 
Enclosing Function : `HistogramCombineGreedy`
Function : `HistoQueuePush` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/libwebp/src/enc/histogram_enc.c#L861
**Issue in**: _histo_queue_

**Code extract**:

```cpp
    for (j = i + 1; j < image_histo_size; ++j) {
      // Initialize queue.
      if (image_histo->histograms[j] == NULL) continue;
      HistoQueuePush(&histo_queue, histograms, i, j, 0.); <------ HERE
    }
  }
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
