### PR TITLE
Potential issue in 3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc: Unchecked return from initialization function

### DIFF
--- a/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc
+++ b/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc
@@ -275,7 +275,7 @@ StatusOr<uint32> ProtoStreamObjectSource::RenderMap(
   uint32 tag_to_return = 0;
   do {
     // Render map entry message type.
-    uint32 buffer32;
+    uint32 buffer32 = 0;
     stream_->ReadVarint32(&buffer32);  // message length
     int old_limit = stream_->PushLimit(buffer32);
     string map_key;
@@ -317,7 +317,7 @@ StatusOr<uint32> ProtoStreamObjectSource::RenderMap(
 
 Status ProtoStreamObjectSource::RenderPacked(
     const google::protobuf::Field* field, ObjectWriter* ow) const {
-  uint32 length;
+  uint32 length = 0;
   stream_->ReadVarint32(&length);
   int old_limit = stream_->PushLimit(length);
   while (stream_->BytesUntilLimit() > 0) {
@@ -496,7 +496,7 @@ Status ProtoStreamObjectSource::RenderString(const ProtoStreamObjectSource* os,
                                              StringPiece field_name,
                                              ObjectWriter* ow) {
   uint32 tag = os->stream_->ReadTag();
-  uint32 buffer32;
+  uint32 buffer32 = 0;
   string str;  // default value of empty for String wrapper
   if (tag != 0) {
     os->stream_->ReadVarint32(&buffer32);  // string size.
@@ -512,7 +512,7 @@ Status ProtoStreamObjectSource::RenderBytes(const ProtoStreamObjectSource* os,
                                             StringPiece field_name,
                                             ObjectWriter* ow) {
   uint32 tag = os->stream_->ReadTag();
-  uint32 buffer32;
+  uint32 buffer32 = 0;
   string str;
   if (tag != 0) {
     os->stream_->ReadVarint32(&buffer32);
@@ -603,12 +603,12 @@ Status ProtoStreamObjectSource::RenderAny(const ProtoStreamObjectSource* os,
     // //google/protobuf/any.proto
     if (field->number() == 1) {
       // read type_url
-      uint32 type_url_size;
+      uint32 type_url_size = 0;
       os->stream_->ReadVarint32(&type_url_size);
       os->stream_->ReadString(&type_url, type_url_size);
     } else if (field->number() == 2) {
       // read value
-      uint32 value_size;
+      uint32 value_size = 0;
       os->stream_->ReadVarint32(&value_size);
       os->stream_->ReadString(&value, value_size);
     }
@@ -663,7 +663,7 @@ Status ProtoStreamObjectSource::RenderFieldMask(
     const ProtoStreamObjectSource* os, const google::protobuf::Type& type,
     StringPiece field_name, ObjectWriter* ow) {
   string combined;
-  uint32 buffer32;
+  uint32 buffer32 = 0;
   uint32 paths_field_tag = 0;
   for (uint32 tag = os->stream_->ReadTag(); tag != 0;
        tag = os->stream_->ReadTag()) {
@@ -750,7 +750,7 @@ Status ProtoStreamObjectSource::RenderField(
   // and ends up using a lot of stack space. Keep the stack usage of this
   // message small in order to preserve stack space and not crash.
   if (field->kind() == google::protobuf::Field_Kind_TYPE_MESSAGE) {
-    uint32 buffer32;
+    uint32 buffer32 = 0;
     stream_->ReadVarint32(&buffer32);  // message length
     int old_limit = stream_->PushLimit(buffer32);
     // Get the nested message type for this field.
@@ -790,8 +790,8 @@ Status ProtoStreamObjectSource::RenderNonMessageField(
     const google::protobuf::Field* field, StringPiece field_name,
     ObjectWriter* ow) const {
   // Temporary buffers of different types.
-  uint32 buffer32;
-  uint64 buffer64;
+  uint32 buffer32 = 0;
+  uint64 buffer64 = 0;
   string strbuffer;
   switch (field->kind()) {
     case google::protobuf::Field_Kind_TYPE_BOOL: {
@@ -918,85 +918,85 @@ const string ProtoStreamObjectSource::ReadFieldValueAsString(
   string result;
   switch (field.kind()) {
     case google::protobuf::Field_Kind_TYPE_BOOL: {
-      uint64 buffer64;
+      uint64 buffer64 = 0;
       stream_->ReadVarint64(&buffer64);
       result = buffer64 != 0 ? "true" : "false";
       break;
     }
     case google::protobuf::Field_Kind_TYPE_INT32: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadVarint32(&buffer32);
       result = SimpleItoa(bit_cast<int32>(buffer32));
       break;
     }
     case google::protobuf::Field_Kind_TYPE_INT64: {
-      uint64 buffer64;
+      uint64 buffer64 = 0;
       stream_->ReadVarint64(&buffer64);
       result = SimpleItoa(bit_cast<int64>(buffer64));
       break;
     }
     case google::protobuf::Field_Kind_TYPE_UINT32: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadVarint32(&buffer32);
       result = SimpleItoa(bit_cast<uint32>(buffer32));
       break;
     }
     case google::protobuf::Field_Kind_TYPE_UINT64: {
-      uint64 buffer64;
+      uint64 buffer64 = 0;
       stream_->ReadVarint64(&buffer64);
       result = SimpleItoa(bit_cast<uint64>(buffer64));
       break;
     }
     case google::protobuf::Field_Kind_TYPE_SINT32: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadVarint32(&buffer32);
       result = SimpleItoa(WireFormatLite::ZigZagDecode32(buffer32));
       break;
     }
     case google::protobuf::Field_Kind_TYPE_SINT64: {
-      uint64 buffer64;
+      uint64 buffer64 = 0;
       stream_->ReadVarint64(&buffer64);
       result = SimpleItoa(WireFormatLite::ZigZagDecode64(buffer64));
       break;
     }
     case google::protobuf::Field_Kind_TYPE_SFIXED32: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadLittleEndian32(&buffer32);
       result = SimpleItoa(bit_cast<int32>(buffer32));
       break;
     }
     case google::protobuf::Field_Kind_TYPE_SFIXED64: {
-      uint64 buffer64;
+      uint64 buffer64 = 0;
       stream_->ReadLittleEndian64(&buffer64);
       result = SimpleItoa(bit_cast<int64>(buffer64));
       break;
     }
     case google::protobuf::Field_Kind_TYPE_FIXED32: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadLittleEndian32(&buffer32);
       result = SimpleItoa(bit_cast<uint32>(buffer32));
       break;
     }
     case google::protobuf::Field_Kind_TYPE_FIXED64: {
-      uint64 buffer64;
+      uint64 buffer64 = 0;
       stream_->ReadLittleEndian64(&buffer64);
       result = SimpleItoa(bit_cast<uint64>(buffer64));
       break;
     }
     case google::protobuf::Field_Kind_TYPE_FLOAT: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadLittleEndian32(&buffer32);
       result = SimpleFtoa(bit_cast<float>(buffer32));
       break;
     }
     case google::protobuf::Field_Kind_TYPE_DOUBLE: {
-      uint64 buffer64;
+      uint64 buffer64 = 0;
       stream_->ReadLittleEndian64(&buffer64);
       result = SimpleDtoa(bit_cast<double>(buffer64));
       break;
     }
     case google::protobuf::Field_Kind_TYPE_ENUM: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadVarint32(&buffer32);
       // Get the nested enum type for this field.
       // TODO(skarvaje): Avoid string manipulation. Find ways to speed this
@@ -1014,13 +1014,13 @@ const string ProtoStreamObjectSource::ReadFieldValueAsString(
       break;
     }
     case google::protobuf::Field_Kind_TYPE_STRING: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadVarint32(&buffer32);  // string size.
       stream_->ReadString(&result, buffer32);
       break;
     }
     case google::protobuf::Field_Kind_TYPE_BYTES: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadVarint32(&buffer32);  // bytes size.
       stream_->ReadString(&result, buffer32);
       break;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

40 instances of this defect were found in the following locations:
---
**Instance 1**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderMap@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L279
**Issue in**: _buffer32_

**Code extract**:

```cpp
  do {
    // Render map entry message type.
    uint32 buffer32;
    stream_->ReadVarint32(&buffer32);  // message length <------ HERE
    int old_limit = stream_->PushLimit(buffer32);
    string map_key;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderPacked@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L321
**Issue in**: _length_

**Code extract**:

```cpp
Status ProtoStreamObjectSource::RenderPacked(
    const google::protobuf::Field* field, ObjectWriter* ow) const {
  uint32 length;
  stream_->ReadVarint32(&length); <------ HERE
  int old_limit = stream_->PushLimit(length);
  while (stream_->BytesUntilLimit() > 0) {
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 3**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L502
**Issue in**: _buffer32_

**Code extract**:

```cpp
  uint32 buffer32;
  string str;  // default value of empty for String wrapper
  if (tag != 0) {
    os->stream_->ReadVarint32(&buffer32);  // string size. <------ HERE
    os->stream_->ReadString(&str, buffer32);
    os->stream_->ReadTag();
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 4**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderBytes@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L518
**Issue in**: _buffer32_

**Code extract**:

```cpp
  uint32 buffer32;
  string str;
  if (tag != 0) {
    os->stream_->ReadVarint32(&buffer32); <------ HERE
    os->stream_->ReadString(&str, buffer32);
    os->stream_->ReadTag();
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 5**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderAny@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L607
**Issue in**: _type_url_size_

**Code extract**:

```cpp
    if (field->number() == 1) {
      // read type_url
      uint32 type_url_size;
      os->stream_->ReadVarint32(&type_url_size); <------ HERE
      os->stream_->ReadString(&type_url, type_url_size);
    } else if (field->number() == 2) {
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 6**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderAny@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L612
**Issue in**: _value_size_

**Code extract**:

```cpp
    } else if (field->number() == 2) {
      // read value
      uint32 value_size;
      os->stream_->ReadVarint32(&value_size); <------ HERE
      os->stream_->ReadString(&value, value_size);
    }
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 7**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderFieldMask@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L682
**Issue in**: _buffer32_

**Code extract**:

```cpp
                          "Invalid FieldMask, unexpected field.");
    }
    string str;
    os->stream_->ReadVarint32(&buffer32);  // string size. <------ HERE
    os->stream_->ReadString(&str, buffer32);
    if (!combined.empty()) {
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 8**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L754
**Issue in**: _buffer32_

**Code extract**:

```cpp
  // message small in order to preserve stack space and not crash.
  if (field->kind() == google::protobuf::Field_Kind_TYPE_MESSAGE) {
    uint32 buffer32;
    stream_->ReadVarint32(&buffer32);  // message length <------ HERE
    int old_limit = stream_->PushLimit(buffer32);
    // Get the nested message type for this field.
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 9**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L798
**Issue in**: _buffer64_

**Code extract**:

```cpp
  string strbuffer;
  switch (field->kind()) {
    case google::protobuf::Field_Kind_TYPE_BOOL: {
      stream_->ReadVarint64(&buffer64); <------ HERE
      ow->RenderBool(field_name, buffer64 != 0);
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 10**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L803
**Issue in**: _buffer32_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_INT32: {
      stream_->ReadVarint32(&buffer32); <------ HERE
      ow->RenderInt32(field_name, bit_cast<int32>(buffer32));
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 11**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L808
**Issue in**: _buffer64_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_INT64: {
      stream_->ReadVarint64(&buffer64); <------ HERE
      ow->RenderInt64(field_name, bit_cast<int64>(buffer64));
      break;
```

**How can I fix it?** 
Correct reference usage found in `3rdparty/protobuf/src/google/protobuf/io/coded_stream.cc` at line `479`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/io/coded_stream.cc#L479
**Code extract**:

```cpp
  // For the slow path, just do a 64-bit read. Try to optimize for one-byte tags
  // again, since we have now refreshed the buffer.
  uint64 result = 0;
  if (!ReadVarint64(&result)) return 0; <------ HERE
  return static_cast<uint32>(result);
}
```

---
**Instance 12**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L813
**Issue in**: _buffer32_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_UINT32: {
      stream_->ReadVarint32(&buffer32); <------ HERE
      ow->RenderUint32(field_name, bit_cast<uint32>(buffer32));
      break;
```

**How can I fix it?** 
Correct reference usage found in `modules/dnn/misc/tensorflow/attr_value.pb.cc` at line `438`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/dnn/misc/tensorflow/attr_value.pb.cc#L438
**Code extract**:

```cpp
        if (static_cast< ::google::protobuf::uint8>(tag) ==
            static_cast< ::google::protobuf::uint8>(50u /* 50 & 0xFF */)) {
          ::google::protobuf::uint32 length;
          DO_(input->ReadVarint32(&length)); <------ HERE
          ::google::protobuf::io::CodedInputStream::Limit limit = input->PushLimit(static_cast<int>(length));
          while (input->BytesUntilLimit() > 0) {
```

---
**Instance 13**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L818
**Issue in**: _buffer64_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_UINT64: {
      stream_->ReadVarint64(&buffer64); <------ HERE
      ow->RenderUint64(field_name, bit_cast<uint64>(buffer64));
      break;
```

**How can I fix it?** 
Correct reference usage found in `3rdparty/protobuf/src/google/protobuf/io/coded_stream.cc` at line `479`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/io/coded_stream.cc#L479
**Code extract**:

```cpp
  // For the slow path, just do a 64-bit read. Try to optimize for one-byte tags
  // again, since we have now refreshed the buffer.
  uint64 result = 0;
  if (!ReadVarint64(&result)) return 0; <------ HERE
  return static_cast<uint32>(result);
}
```

---
**Instance 14**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L823
**Issue in**: _buffer32_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_SINT32: {
      stream_->ReadVarint32(&buffer32); <------ HERE
      ow->RenderInt32(field_name, WireFormatLite::ZigZagDecode32(buffer32));
      break;
```

**How can I fix it?** 
Correct reference usage found in `modules/dnn/misc/tensorflow/attr_value.pb.cc` at line `438`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/dnn/misc/tensorflow/attr_value.pb.cc#L438
**Code extract**:

```cpp
        if (static_cast< ::google::protobuf::uint8>(tag) ==
            static_cast< ::google::protobuf::uint8>(50u /* 50 & 0xFF */)) {
          ::google::protobuf::uint32 length;
          DO_(input->ReadVarint32(&length)); <------ HERE
          ::google::protobuf::io::CodedInputStream::Limit limit = input->PushLimit(static_cast<int>(length));
          while (input->BytesUntilLimit() > 0) {
```

---
**Instance 15**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L828
**Issue in**: _buffer64_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_SINT64: {
      stream_->ReadVarint64(&buffer64); <------ HERE
      ow->RenderInt64(field_name, WireFormatLite::ZigZagDecode64(buffer64));
      break;
```

**How can I fix it?** 
Correct reference usage found in `3rdparty/protobuf/src/google/protobuf/io/coded_stream.cc` at line `479`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/io/coded_stream.cc#L479
**Code extract**:

```cpp
  // For the slow path, just do a 64-bit read. Try to optimize for one-byte tags
  // again, since we have now refreshed the buffer.
  uint64 result = 0;
  if (!ReadVarint64(&result)) return 0; <------ HERE
  return static_cast<uint32>(result);
}
```

---
**Instance 16**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadLittleEndian32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L833
**Issue in**: _buffer32_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_SFIXED32: {
      stream_->ReadLittleEndian32(&buffer32); <------ HERE
      ow->RenderInt32(field_name, bit_cast<int32>(buffer32));
      break;
```

**How can I fix it?** 
Correct reference usage found in `3rdparty/protobuf/src/google/protobuf/wire_format_lite.cc` at line `219`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/wire_format_lite.cc#L219
**Code extract**:

```cpp
    }
    case WireFormatLite::WIRETYPE_FIXED32: {
      uint32 value;
      if (!input->ReadLittleEndian32(&value)) return false; <------ HERE
      output->WriteVarint32(tag);
      output->WriteLittleEndian32(value);
```

---
**Instance 17**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadLittleEndian64@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L838
**Issue in**: _buffer64_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_SFIXED64: {
      stream_->ReadLittleEndian64(&buffer64); <------ HERE
      ow->RenderInt64(field_name, bit_cast<int64>(buffer64));
      break;
```

**How can I fix it?** 
Correct reference usage found in `3rdparty/protobuf/src/google/protobuf/wire_format_lite.cc` at line `185`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/wire_format_lite.cc#L185
**Code extract**:

```cpp
    }
    case WireFormatLite::WIRETYPE_FIXED64: {
      uint64 value;
      if (!input->ReadLittleEndian64(&value)) return false; <------ HERE
      output->WriteVarint32(tag);
      output->WriteLittleEndian64(value);
```

---
**Instance 18**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadLittleEndian32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L843
**Issue in**: _buffer32_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_FIXED32: {
      stream_->ReadLittleEndian32(&buffer32); <------ HERE
      ow->RenderUint32(field_name, bit_cast<uint32>(buffer32));
      break;
```

**How can I fix it?** 
Correct reference usage found in `3rdparty/protobuf/src/google/protobuf/wire_format_lite.cc` at line `219`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/wire_format_lite.cc#L219
**Code extract**:

```cpp
    }
    case WireFormatLite::WIRETYPE_FIXED32: {
      uint32 value;
      if (!input->ReadLittleEndian32(&value)) return false; <------ HERE
      output->WriteVarint32(tag);
      output->WriteLittleEndian32(value);
```

---
**Instance 19**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadLittleEndian64@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L848
**Issue in**: _buffer64_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_FIXED64: {
      stream_->ReadLittleEndian64(&buffer64); <------ HERE
      ow->RenderUint64(field_name, bit_cast<uint64>(buffer64));
      break;
```

**How can I fix it?** 
Correct reference usage found in `3rdparty/protobuf/src/google/protobuf/wire_format_lite.cc` at line `185`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/wire_format_lite.cc#L185
**Code extract**:

```cpp
    }
    case WireFormatLite::WIRETYPE_FIXED64: {
      uint64 value;
      if (!input->ReadLittleEndian64(&value)) return false; <------ HERE
      output->WriteVarint32(tag);
      output->WriteLittleEndian64(value);
```

---
**Instance 20**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadLittleEndian32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L853
**Issue in**: _buffer32_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_FLOAT: {
      stream_->ReadLittleEndian32(&buffer32); <------ HERE
      ow->RenderFloat(field_name, bit_cast<float>(buffer32));
      break;
```

**How can I fix it?** 
Correct reference usage found in `3rdparty/protobuf/src/google/protobuf/wire_format_lite.cc` at line `219`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/wire_format_lite.cc#L219
**Code extract**:

```cpp
    }
    case WireFormatLite::WIRETYPE_FIXED32: {
      uint32 value;
      if (!input->ReadLittleEndian32(&value)) return false; <------ HERE
      output->WriteVarint32(tag);
      output->WriteLittleEndian32(value);
```

---
**Instance 21**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadLittleEndian64@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L858
**Issue in**: _buffer64_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_DOUBLE: {
      stream_->ReadLittleEndian64(&buffer64); <------ HERE
      ow->RenderDouble(field_name, bit_cast<double>(buffer64));
      break;
```

**How can I fix it?** 
Correct reference usage found in `3rdparty/protobuf/src/google/protobuf/wire_format_lite.cc` at line `185`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/wire_format_lite.cc#L185
**Code extract**:

```cpp
    }
    case WireFormatLite::WIRETYPE_FIXED64: {
      uint64 value;
      if (!input->ReadLittleEndian64(&value)) return false; <------ HERE
      output->WriteVarint32(tag);
      output->WriteLittleEndian64(value);
```

---
**Instance 22**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L863
**Issue in**: _buffer32_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_ENUM: {
      stream_->ReadVarint32(&buffer32); <------ HERE

      // If the field represents an explicit NULL value, render null.
```

**How can I fix it?** 
Correct reference usage found in `modules/dnn/misc/tensorflow/attr_value.pb.cc` at line `438`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/dnn/misc/tensorflow/attr_value.pb.cc#L438
**Code extract**:

```cpp
        if (static_cast< ::google::protobuf::uint8>(tag) ==
            static_cast< ::google::protobuf::uint8>(50u /* 50 & 0xFF */)) {
          ::google::protobuf::uint32 length;
          DO_(input->ReadVarint32(&length)); <------ HERE
          ::google::protobuf::io::CodedInputStream::Limit limit = input->PushLimit(static_cast<int>(length));
          while (input->BytesUntilLimit() > 0) {
```

---
**Instance 23**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L898
**Issue in**: _buffer32_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_STRING: {
      stream_->ReadVarint32(&buffer32);  // string size. <------ HERE
      stream_->ReadString(&strbuffer, buffer32);
      ow->RenderString(field_name, strbuffer);
```

**How can I fix it?** 
Correct reference usage found in `modules/dnn/misc/tensorflow/attr_value.pb.cc` at line `438`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/dnn/misc/tensorflow/attr_value.pb.cc#L438
**Code extract**:

```cpp
        if (static_cast< ::google::protobuf::uint8>(tag) ==
            static_cast< ::google::protobuf::uint8>(50u /* 50 & 0xFF */)) {
          ::google::protobuf::uint32 length;
          DO_(input->ReadVarint32(&length)); <------ HERE
          ::google::protobuf::io::CodedInputStream::Limit limit = input->PushLimit(static_cast<int>(length));
          while (input->BytesUntilLimit() > 0) {
```

---
**Instance 24**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderNonMessageField@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L904
**Issue in**: _buffer32_

**Code extract**:

```cpp
      break;
    }
    case google::protobuf::Field_Kind_TYPE_BYTES: {
      stream_->ReadVarint32(&buffer32);  // bytes size. <------ HERE
      stream_->ReadString(&strbuffer, buffer32);
      ow->RenderBytes(field_name, strbuffer);
```

**How can I fix it?** 
Correct reference usage found in `modules/dnn/misc/tensorflow/attr_value.pb.cc` at line `438`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/dnn/misc/tensorflow/attr_value.pb.cc#L438
**Code extract**:

```cpp
        if (static_cast< ::google::protobuf::uint8>(tag) ==
            static_cast< ::google::protobuf::uint8>(50u /* 50 & 0xFF */)) {
          ::google::protobuf::uint32 length;
          DO_(input->ReadVarint32(&length)); <------ HERE
          ::google::protobuf::io::CodedInputStream::Limit limit = input->PushLimit(static_cast<int>(length));
          while (input->BytesUntilLimit() > 0) {
```

---
**Instance 25**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L922
**Issue in**: _buffer64_

**Code extract**:

```cpp
  switch (field.kind()) {
    case google::protobuf::Field_Kind_TYPE_BOOL: {
      uint64 buffer64;
      stream_->ReadVarint64(&buffer64); <------ HERE
      result = buffer64 != 0 ? "true" : "false";
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 26**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L928
**Issue in**: _buffer32_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_INT32: {
      uint32 buffer32;
      stream_->ReadVarint32(&buffer32); <------ HERE
      result = SimpleItoa(bit_cast<int32>(buffer32));
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 27**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L934
**Issue in**: _buffer64_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_INT64: {
      uint64 buffer64;
      stream_->ReadVarint64(&buffer64); <------ HERE
      result = SimpleItoa(bit_cast<int64>(buffer64));
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 28**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L940
**Issue in**: _buffer32_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_UINT32: {
      uint32 buffer32;
      stream_->ReadVarint32(&buffer32); <------ HERE
      result = SimpleItoa(bit_cast<uint32>(buffer32));
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 29**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L946
**Issue in**: _buffer64_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_UINT64: {
      uint64 buffer64;
      stream_->ReadVarint64(&buffer64); <------ HERE
      result = SimpleItoa(bit_cast<uint64>(buffer64));
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 30**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L952
**Issue in**: _buffer32_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_SINT32: {
      uint32 buffer32;
      stream_->ReadVarint32(&buffer32); <------ HERE
      result = SimpleItoa(WireFormatLite::ZigZagDecode32(buffer32));
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 31**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L958
**Issue in**: _buffer64_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_SINT64: {
      uint64 buffer64;
      stream_->ReadVarint64(&buffer64); <------ HERE
      result = SimpleItoa(WireFormatLite::ZigZagDecode64(buffer64));
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 32**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadLittleEndian32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L964
**Issue in**: _buffer32_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_SFIXED32: {
      uint32 buffer32;
      stream_->ReadLittleEndian32(&buffer32); <------ HERE
      result = SimpleItoa(bit_cast<int32>(buffer32));
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 33**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadLittleEndian64@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L970
**Issue in**: _buffer64_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_SFIXED64: {
      uint64 buffer64;
      stream_->ReadLittleEndian64(&buffer64); <------ HERE
      result = SimpleItoa(bit_cast<int64>(buffer64));
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 34**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadLittleEndian32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L976
**Issue in**: _buffer32_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_FIXED32: {
      uint32 buffer32;
      stream_->ReadLittleEndian32(&buffer32); <------ HERE
      result = SimpleItoa(bit_cast<uint32>(buffer32));
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 35**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadLittleEndian64@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L982
**Issue in**: _buffer64_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_FIXED64: {
      uint64 buffer64;
      stream_->ReadLittleEndian64(&buffer64); <------ HERE
      result = SimpleItoa(bit_cast<uint64>(buffer64));
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 36**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadLittleEndian32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L988
**Issue in**: _buffer32_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_FLOAT: {
      uint32 buffer32;
      stream_->ReadLittleEndian32(&buffer32); <------ HERE
      result = SimpleFtoa(bit_cast<float>(buffer32));
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 37**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadLittleEndian64@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L994
**Issue in**: _buffer64_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_DOUBLE: {
      uint64 buffer64;
      stream_->ReadLittleEndian64(&buffer64); <------ HERE
      result = SimpleDtoa(bit_cast<double>(buffer64));
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 38**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L1000
**Issue in**: _buffer32_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_ENUM: {
      uint32 buffer32;
      stream_->ReadVarint32(&buffer32); <------ HERE
      // Get the nested enum type for this field.
      // TODO(skarvaje): Avoid string manipulation. Find ways to speed this
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 39**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L1018
**Issue in**: _buffer32_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_STRING: {
      uint32 buffer32;
      stream_->ReadVarint32(&buffer32);  // string size. <------ HERE
      stream_->ReadString(&result, buffer32);
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
---
**Instance 40**
File : `3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `ReadFieldValueAsString@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/3rdparty/protobuf/src/google/protobuf/util/internal/protostream_objectsource.cc#L1024
**Issue in**: _buffer32_

**Code extract**:

```cpp
    }
    case google::protobuf::Field_Kind_TYPE_BYTES: {
      uint32 buffer32;
      stream_->ReadVarint32(&buffer32);  // bytes size. <------ HERE
      stream_->ReadString(&result, buffer32);
      break;
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
