### PR TITLE
Potential issue in modules/videoio/src/cap_dshow.cpp: Unchecked return from initialization function

### DIFF
--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -3145,7 +3145,7 @@ HRESULT videoInput::ShowFilterPropertyPages(IBaseFilter *pFilter){
         // Get the filter's name and IUnknown pointer.
         FILTER_INFO FilterInfo;
         hr = pFilter->QueryFilterInfo(&FilterInfo);
-        IUnknown *pFilterUnk;
+        IUnknown *pFilterUnk = nullptr;
         pFilter->QueryInterface(IID_IUnknown, (void **)&pFilterUnk);
 
         // Show the page.


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

5 instances of this defect were found in the following locations:

---
**Instance 1**
File : `modules/videoio/src/cap_dshow.cpp` 
Enclosing Function : `setVideoSettingFilter@videoInput`
Function : `GetRange@IAMVideoProcAmp` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/videoio/src/cap_dshow.cpp#L1856
**Issue in**: _Default_

**Code extract**:

```cpp
    long CurrVal, Min, Max, SteppingDelta, Default, CapsFlags, AvailableCapsFlags = 0;


    pAMVideoProcAmp->GetRange(Property, &Min, &Max, &SteppingDelta, &Default, &AvailableCapsFlags); <------ HERE
    DebugPrintOut("Range for video setting %s: Min:%ld Max:%ld SteppingDelta:%ld Default:%ld Flags:%ld\n", propStr, Min, Max, SteppingDelta, Default, AvailableCapsFlags);
    pAMVideoProcAmp->Get(Property, &CurrVal, &CapsFlags);
```

**How can I fix it?** 
Correct reference usage found in `modules/videoio/src/cap_msmf.cpp` at line `1137`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/videoio/src/cap_msmf.cpp#L1137
**Code extract**:

```cpp
    }
    // fallback - get default value
    long minVal, maxVal, stepVal;
    if (FAILED(ctrl->GetRange(prop, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag))) <------ HERE
    {
        CV_LOG_DEBUG(NULL, "Failed to get default value for property " << prop);
```


---
**Instance 2**
File : `modules/videoio/src/cap_dshow.cpp` 
Enclosing Function : `setVideoSettingFilter@videoInput`
Function : `Get@IAMVideoProcAmp` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/videoio/src/cap_dshow.cpp#L1858
**Issue in**: _CapsFlags_

**Code extract**:

```cpp

    pAMVideoProcAmp->GetRange(Property, &Min, &Max, &SteppingDelta, &Default, &AvailableCapsFlags);
    DebugPrintOut("Range for video setting %s: Min:%ld Max:%ld SteppingDelta:%ld Default:%ld Flags:%ld\n", propStr, Min, Max, SteppingDelta, Default, AvailableCapsFlags);
    pAMVideoProcAmp->Get(Property, &CurrVal, &CapsFlags); <------ HERE

    DebugPrintOut("Current value: %ld Flags %ld (%s)\n", CurrVal, CapsFlags, (CapsFlags == 1 ? "Auto" : (CapsFlags == 2 ? "Manual" : "Unknown")));
```

**How can I fix it?** 
Correct reference usage found in `modules/videoio/src/cap_msmf.cpp` at line `1130`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/videoio/src/cap_msmf.cpp#L1130
**Code extract**:

```cpp
        return false;
    }
    long paramVal, paramFlag;
    if (FAILED(ctrl->Get(prop, &paramVal, &paramFlag))) <------ HERE
    {
        CV_LOG_DEBUG(NULL, "Failed to get property " << prop);
```


---
**Instance 3**
File : `modules/videoio/src/cap_dshow.cpp` 
Enclosing Function : `setVideoSettingCamera@videoInput`
Function : `GetRange@IAMCameraControl` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/videoio/src/cap_dshow.cpp#L1939
**Issue in**: _AvailableCapsFlags_

**Code extract**:

```cpp
        else
        {
            long CurrVal, Min, Max, SteppingDelta, Default, CapsFlags, AvailableCapsFlags;
            pIAMCameraControl->GetRange(Property, &Min, &Max, &SteppingDelta, &Default, &AvailableCapsFlags); <------ HERE
            DebugPrintOut("Range for video setting %s: Min:%ld Max:%ld SteppingDelta:%ld Default:%ld Flags:%ld\n", propStr, Min, Max, SteppingDelta, Default, AvailableCapsFlags);
            pIAMCameraControl->Get(Property, &CurrVal, &CapsFlags);
```

**How can I fix it?** 
Correct reference usage found in `modules/videoio/src/cap_msmf.cpp` at line `1137`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/videoio/src/cap_msmf.cpp#L1137
**Code extract**:

```cpp
    }
    // fallback - get default value
    long minVal, maxVal, stepVal;
    if (FAILED(ctrl->GetRange(prop, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag))) <------ HERE
    {
        CV_LOG_DEBUG(NULL, "Failed to get default value for property " << prop);
```


---
**Instance 4**
File : `modules/videoio/src/cap_dshow.cpp` 
Enclosing Function : `setVideoSettingCamera@videoInput`
Function : `Get@IAMCameraControl` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/videoio/src/cap_dshow.cpp#L1941
**Issue in**: _CapsFlags_

**Code extract**:

```cpp
            long CurrVal, Min, Max, SteppingDelta, Default, CapsFlags, AvailableCapsFlags;
            pIAMCameraControl->GetRange(Property, &Min, &Max, &SteppingDelta, &Default, &AvailableCapsFlags);
            DebugPrintOut("Range for video setting %s: Min:%ld Max:%ld SteppingDelta:%ld Default:%ld Flags:%ld\n", propStr, Min, Max, SteppingDelta, Default, AvailableCapsFlags);
            pIAMCameraControl->Get(Property, &CurrVal, &CapsFlags); <------ HERE
            DebugPrintOut("Current value: %ld Flags %ld (%s)\n", CurrVal, CapsFlags, (CapsFlags == 1 ? "Auto" : (CapsFlags == 2 ? "Manual" : "Unknown")));
            if (useDefaultValue) {
```

**How can I fix it?** 
Correct reference usage found in `modules/videoio/src/cap_msmf.cpp` at line `1130`.
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/videoio/src/cap_msmf.cpp#L1130
**Code extract**:

```cpp
        return false;
    }
    long paramVal, paramFlag;
    if (FAILED(ctrl->Get(prop, &paramVal, &paramFlag))) <------ HERE
    {
        CV_LOG_DEBUG(NULL, "Failed to get property " << prop);
```


---
**Instance 5**
File : `modules/videoio/src/cap_dshow.cpp` 
Enclosing Function : `ShowFilterPropertyPages@videoInput`
Function : `QueryInterface@IUnknown` 
https://github.com/sagpant/opencv/blob/55ca0fcc279bf5257b104854feadacf8082f9302/modules/videoio/src/cap_dshow.cpp#L3149
**Issue in**: _pFilterUnk_

**Code extract**:

```cpp
        FILTER_INFO FilterInfo;
        hr = pFilter->QueryFilterInfo(&FilterInfo);
        IUnknown *pFilterUnk;
        pFilter->QueryInterface(IID_IUnknown, (void **)&pFilterUnk); <------ HERE

        // Show the page.
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
